### PR TITLE
added same max-width to align with centraliser/body content

### DIFF
--- a/src/assets/toolkit/styles/6-components/navigation/_components.global.scss
+++ b/src/assets/toolkit/styles/6-components/navigation/_components.global.scss
@@ -221,6 +221,8 @@ $overlay-padding-offset: 3.8rem;
 
         @include clearfix();
 
+        max-width: 88em;
+        
         position: relative;
 
         .search {


### PR DESCRIPTION
added same max-width on gloval nav bar, to align with centraliser/body content