### PR TITLE
Fix link-external icon alignment issue

### DIFF
--- a/src/assets/toolkit/styles/5-objects/_objects.icons.scss
+++ b/src/assets/toolkit/styles/5-objects/_objects.icons.scss
@@ -116,7 +116,6 @@ $icon-play-triangle-ratio: 1.1; // Ratio between width and height of the triangl
 .link-external {
   @include extend-icon-after( external ) {
     margin-left: _em( $gap-small );
-    vertical-align: 0;
   }
 }
 
@@ -145,7 +144,3 @@ $icon-play-triangle-ratio: 1.1; // Ratio between width and height of the triangl
 .link-audio {
   @include extend-icon-before( audio );
 }
-
-
-
-


### PR DESCRIPTION
Fix link-external alignment issue in CSS i.e. [see here](https://www.victoria.ac.nz/autism-clinic/research/completed-research/supporting-parents-in-the-use-of-the-early-start-denver-model-for-their-young-children-with-autism-spectrum-disorder)