### PR TITLE
FIX; Make meta highlight tags work without a tag

### DIFF
--- a/src/assets/toolkit/styles/5-objects/_objects.meta.scss
+++ b/src/assets/toolkit/styles/5-objects/_objects.meta.scss
@@ -37,13 +37,14 @@ ul.meta {
       }
     };
 
-    > a {
+    > a, > span {
       display: block;
       padding: .2rem .5rem;
       background-color: _tint( $meta-bg, $lighter-percentage ); //TODO: Can it be replaced by some of the pre-defined colour?
       color: $heading-color;
       text-decoration: none;
-
+    }
+    > a {
       @include hoverify {
         text-decoration: underline;
       }


### PR DESCRIPTION
Currently if you want a highlight tag you have to do this:

```
<ul class="meta">
  <li class="highlight">
    <a href="#">Item</a>
  </li>
</ul>
```

What if you don't want a link? Now you can do this:

```
<ul class="meta">
  <li class="highlight">
    <span>Item</span>
  </li>
</ul>
```
